### PR TITLE
Allow multiple set of arguments to the partials

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3c6af7f205055eea8814f6886266596c",
     "content-hash": "0ef86976ee841d857fc492a40f0896f6",
     "packages": [],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +83,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -120,7 +119,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-02-01 16:14:59"
+            "time": "2016-02-01T16:14:59+00:00"
         }
     ],
     "aliases": [],

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Loader [![Build Status](https://travis-ci.org/moxie-lean/loader.svg?branch=master)](https://travis-ci.org/moxie-lean/loader)
+#Loader [![Build Status](https://travis-ci.org/moxie-lean/loader.svg?branch=master)](https://travis-ci.org/moxie-lean/loader)  
 
 > Allows to load files from directories with a more sugared syntax, and
 > allowing the use of params passed to the file.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-#Loader [![Build Status](https://travis-ci.org/moxie-lean/loader.svg?branch=master)](https://travis-ci.org/moxie-lean/loader)  
+# Loader  
+
+[![Build Status](https://travis-ci.org/moxie-lean/loader.svg?branch=master)](https://travis-ci.org/moxie-lean/loader) 
 
 > Allows to load files from directories with a more sugared syntax, and
 > allowing the use of params passed to the file.

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,8 @@ sets are merged into a single one with `wp_parse_args` to create a single set.
 
 ```php
 <?php 
+use Lean\Load;
+
 $set_1 = [
   'a' => 1,
   'b' => 5,

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ you have the follow benefits:
 
 - More clear sintax of what files and from where are loaded.
 - Allow to send variables between files loaded.
+- Multiple set of arguments to the partials. 
+- Keep things DRY.
 
 # Requirements
 
@@ -48,17 +50,20 @@ $args = [
 Load::partials( 'single', $args );
 ```
 
-The function accepts two arguments:
+The function accepts at least two arguments:
 
 - `$file`, in the example above `single`. This is the filename wanted to load.
 The extension is optional, in this case we want to load the file `single.php` from
 the `partials` directory, you can create an alias for directories 
 ([see alias for more information](#register-an-alias)) to use a different name for that directory.
 
-- `$args`, an associative array with the values that we wanted to pass to the 
+- `...$args`, an associative array with the values that we wanted to pass to the 
 loaded file, the array can have any number of elements as long as it's a 
 valid associative array. Those values are available on the loaded file via 
 the `$args` variable and can be used as follows:
+
+You can send as many set of arguments as you want, at the end all
+sets are merged into a single one with `wp_parse_args` to create a single set. 
 
 ```php
 <?php 
@@ -69,6 +74,28 @@ the `$args` variable and can be used as follows:
 <a href="<?php echo esc_url( $args['url'] ); ?>" target="<?php echo esc_attr( $args['target'] ); ?>">
   <?php echo esc_html( $args['title'] ); ?>
 </a>
+```
+
+### Multiple set of arguments.
+
+```php
+<?php 
+$set_1 = [
+  'a' => 1,
+  'b' => 5,
+  'c' => 3
+];
+$set_2 = [
+  'a' => 10,
+  'd' => 3
+];
+$set_3 = [
+  'd' => 10,
+  'c' => 2,
+  'r' => 3,
+];
+// You can have as many sets as you want.
+Load::partials( 'single', $set_1, $set_2, $set_3 ) ?>
 ```
 
 ## Tips

--- a/src/Load.php
+++ b/src/Load.php
@@ -28,7 +28,7 @@ class Load {
 		$args = [];
 		// The start point is 1 as the 0 is the name of the file to be loadeed.
 		// So we make sure every next set of arguments are merged with the original set of arguments.
-		for( $i = 1; $i < $total; $i++ ) {
+		for ( $i = 1; $i < $total; $i++ ) {
 			$args = wp_parse_args( $arguments[ $i ], $args );
 		}
 		self::loader( $file, $type, $args );

--- a/src/Load.php
+++ b/src/Load.php
@@ -29,7 +29,10 @@ class Load {
 		// The start point is 1 as the 0 is the name of the file to be loadeed.
 		// So we make sure every next set of arguments are merged with the original set of arguments.
 		for ( $i = 1; $i < $total; $i++ ) {
-			$args = wp_parse_args( $arguments[ $i ], $args );
+			$set = $arguments[ $i ];
+			if ( is_array( $set ) ) {
+				$args = wp_parse_args( $set, $args );
+			}
 		}
 		self::loader( $file, $type, $args );
 	}

--- a/src/Load.php
+++ b/src/Load.php
@@ -24,7 +24,13 @@ class Load {
 			return;
 		}
 		$file = $arguments[0];
-		$args = count( $arguments ) >= 2 ? $arguments[1] : [];
+		$total = count( $arguments );
+		$args = [];
+		// The start point is 1 as the 0 is the name of the file to be loadeed.
+		// So we make sure every next set of arguments are merged with the original set of arguments.
+		for( $i = 1; $i < $total; $i++ ) {
+			$args = wp_parse_args( $arguments[ $i ], $args );
+		}
 		self::loader( $file, $type, $args );
 	}
 


### PR DESCRIPTION
With this change the introduction of variable set of arguments is enabled so we can send multiple set of arguments. Every new set is merged with the initial set so at the end we end up with a single set with all the previous sets merged as with others frameworks such as `React` or `Object.assign` or `wp_parse_args`.